### PR TITLE
Added supporting of links in headers.

### DIFF
--- a/GitHubToCBuilder.user.js
+++ b/GitHubToCBuilder.user.js
@@ -20,7 +20,7 @@
 
   const getHeaderText = headerLine => {
     return headerLine.replace(/#+\s+/, '')
-                     // Keep only link text
+                     // For link in header we keep text only (remove URL and brackets) 
                      .replace(/\[(.*?)\]\(.*?\)/g, '$1');
   }
 

--- a/GitHubToCBuilder.user.js
+++ b/GitHubToCBuilder.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         GitHubToCBuilder
 // @namespace    https://scand.com/
-// @version      0.1.4
+// @version      0.1.5
 // @description  ToC builder for GitHub markdown markup docs (.md and Wiki)
 // @author       vkuleshov-sc
 // @author       achernyakevich-sc
@@ -19,7 +19,9 @@
   }
 
   const getHeaderText = headerLine => {
-    return headerLine.replace(/#+\s+/, '');
+    return headerLine.replace(/#+\s+/, '')
+                     // Keep only link text
+                     .replace(/\[(.*?)\]\(.*?\)/g, '$1');
   }
 
   const getHeaderAnchor = headerText => {
@@ -107,6 +109,11 @@
       {
         input: '# header1 and some text',
         output: 'header1 and some text',
+        testingFunc: getHeaderText,
+      },
+      {
+        input: '# Header with [GitHub](https://github.com/) and [Google](https://google.com/) links',
+        output: 'Header with GitHub and Google links',
         testingFunc: getHeaderText,
       },
       {

--- a/TEST.md
+++ b/TEST.md
@@ -1,0 +1,18 @@
+- [ToC Example](#toc-example)
+  - [Header level 2](#header-level-2)
+    - [Header level 3](#header-level-3)
+  - [Header with GitHub and Google links](#header-with-github-and-google-links)
+
+# ToC Example
+
+## Header level 2
+
+Quisque ornare at augue et tincidunt. Quisque facilisis, nibh eget egestas molestie, nisi enim mattis nisi, sit amet pretium felis tortor eu eros. Duis vitae tellus molestie, sagittis tellus id, faucibus neque. Vestibulum iaculis convallis neque id viverra.
+
+### Header level 3
+
+Vestibulum ac dolor orci. Nullam varius porttitor convallis. Proin id suscipit magna, non suscipit velit. Integer mattis venenatis sem, at laoreet ipsum luctus eget. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae.
+
+## Header with [GitHub](https://github.com/) and [Google](https://google.com/) links
+
+There are cases when a header could contain links, e.g. to Jira-tickets.


### PR DESCRIPTION
If headers contain links it breaks ToC. This fix solves the problem. See an example (header links have already been fixed there):
https://github.com/achernyakevich-sc/github-markdown-toc/blob/9659fb402d226c6f320c535fe8083035421581f4/TEST.md